### PR TITLE
Updated the makefile to work with ubuntu's Monodevelop install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,12 @@ MD_DIST_DIR = ${MD_BUILD_DIR}/mwf-designer
 ASSEMBLY=mwf-designer.exe
 
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
-COMPILER = $(call pathsearch,dmcs)
+
+COMPILER = $(call pathsearch,mcs)
+ifeq ($(strip $(COMPILER)),)
+    COMPILER = dmcs
+endif
+
 ifeq ($(strip $(COMPILER)),)
     COMPILER = gmcs
 endif

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 
 COMPILER = $(call pathsearch,mcs)
 ifeq ($(strip $(COMPILER)),)
-    COMPILER = dmcs
+    COMPILER = $(call pathsearch,dmcs)
 endif
 
 ifeq ($(strip $(COMPILER)),)

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,20 @@ DEPS = ${DEPS_DIR}/*.dll
 DIST_DIR = ${BUILD_DIR}/mwf-designer-dist
 MD_DIST_DIR = ${MD_BUILD_DIR}/mwf-designer
 ASSEMBLY=mwf-designer.exe
+
+pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
+COMPILER = $(call pathsearch,dmcs)
+ifeq ($(strip $(COMPILER)),)
+    COMPILER = gmcs
+endif
+
 REFERENCES=System.Design,System.Windows.Forms,System.Drawing,System.Data,${DEPS_DIR}/ICSharpCode.NRefactory.dll
 
 all: ${BUILD_DIR}/${ASSEMBLY}
 
 ${BUILD_DIR}/${ASSEMBLY}: ${SOURCES}
 	mkdir -p ${BUILD_DIR}
-	MCS_COLORS=disable gmcs -debug -r:${REFERENCES} -out:${BUILD_DIR}/${ASSEMBLY} ${SOURCES}
+	MCS_COLORS=disable ${COMPILER} -debug -r:${REFERENCES} -out:${BUILD_DIR}/${ASSEMBLY} ${SOURCES}
 
 run: all
 	cp ${DEPS_DIR}/*.dll ${BUILD_DIR}
@@ -20,7 +27,7 @@ run: all
 
 mono-design: all
 	cd ${DEPS_DIR}/Mono.Design && make
-	export MCS_COLORS=disable;gmcs -debug -r:${REFERENCES},${DEPS_DIR}/Mono.Design.dll -out:${BUILD_DIR}/${ASSEMBLY} ${SOURCES}
+	export MCS_COLORS=disable;${COMPILER} -debug -r:${REFERENCES},${DEPS_DIR}/Mono.Design.dll -out:${BUILD_DIR}/${ASSEMBLY} ${SOURCES}
 
 mono-design-update:
 	cd ${DEPS_DIR}/Mono.Design && make update


### PR DESCRIPTION
ubuntu by default uses dmcs instead of gmcs, I've added checks to see if dmcs exists.
If dmcs doesn't exist, I continue to use gmcs.
