### PR TITLE
update: fix some bitrot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+deps/Mono.Design/.generated
+deps/Mono.Design/class/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: ${BUILD_DIR}/${ASSEMBLY}
 
 ${BUILD_DIR}/${ASSEMBLY}: ${SOURCES}
 	mkdir -p ${BUILD_DIR}
-	MCS_COLORS=disable gmcs -debug -r:${REFERENCES} -out:${BUILD_DIR}/${ASSEMBLY} ${SOURCES}
+	MCS_COLORS=disable mcs -debug -r:${REFERENCES} -out:${BUILD_DIR}/${ASSEMBLY} ${SOURCES}
 
 run: all
 	cp ${DEPS_DIR}/*.dll ${BUILD_DIR}
@@ -20,7 +20,7 @@ run: all
 
 mono-design: all
 	cd ${DEPS_DIR}/Mono.Design && make
-	export MCS_COLORS=disable;gmcs -debug -r:${REFERENCES},${DEPS_DIR}/Mono.Design.dll -out:${BUILD_DIR}/${ASSEMBLY} ${SOURCES}
+	export MCS_COLORS=disable;mcs -debug -r:${REFERENCES},${DEPS_DIR}/Mono.Design.dll -out:${BUILD_DIR}/${ASSEMBLY} ${SOURCES}
 
 mono-design-update:
 	cd ${DEPS_DIR}/Mono.Design && make update

--- a/deps/Mono.Design/Makefile
+++ b/deps/Mono.Design/Makefile
@@ -6,7 +6,7 @@ REFERENCES=System.Design,System.Windows.Forms,System.Drawing
 all: generate-md net-2
 
 net-2:
-	export MCS_COLORS=disable;gmcs -d:NET_2_0,DEBUG -target:library -debug -r:${REFERENCES} -out:${ASSEMBLY} ${SOURCES}
+	export MCS_COLORS=disable;mcs -d:NET_2_0,DEBUG -target:library -debug -r:${REFERENCES} -out:${ASSEMBLY} ${SOURCES}
 
 net-1:
 	export MCS_COLORS=disable;mcs -d:DEBUG,NET_1_1 -t:library -debug -r:${REFERENCES} -out:${ASSEMBLY} ${SOURCES}

--- a/deps/Mono.Design/Makefile
+++ b/deps/Mono.Design/Makefile
@@ -19,6 +19,6 @@ update: clean
 
 generate-md:
 ifeq (,$(findstring .generated,$(wildcard .*)))
-	python generate-mono-design.py
+	python3 generate-mono-design.py
 	touch .generated
 endif

--- a/deps/Mono.Design/generate-mono-design.py
+++ b/deps/Mono.Design/generate-mono-design.py
@@ -21,34 +21,34 @@ def main ():
         print (exc)
 
 def fetch_source_code (files):
-    for file in files:
-        directory = os.path.dirname (file)
+    for file_ in files:
+        directory = os.path.dirname (file_)
         if directory != "": # quick hack to only download assembly files and not the ones we already have
             if not os.path.exists (directory):
                 os.makedirs (directory)
             for i in range (1, 4): # retry 3 times
                 try:
-                    webFile = urllib.request.urlopen (file_to_url (file))
-                    localFile = open (file, 'wb+')
+                    webFile = urllib.request.urlopen (file_to_url (file_))
+                    localFile = open (file_, 'wb+')
                     localFile.write (webFile.read())
                     webFile.close ()
                     localFile.close ()
-                    print ("A " + file)
+                    print ("A " + file_)
                     break
                 except Exception as exc:
-                    print ("E " + file)
+                    print ("E " + file_)
                     print (exc)
 
-def file_to_url (file):
-    return "http://anonsvn.mono-project.com/viewvc/trunk/mcs/" + file + "?view=co"
+def file_to_url (file_):
+    return "https://raw.githubusercontent.com/mono/mono/master/mcs/" + file_
 
 def get_files ():
     try:
-        file = open ("Mono.Design.sources")
+        file_ = open ("Mono.Design.sources")
         filesList = []
-        for fileEntry in file:
+        for fileEntry in file_:
             filesList.append (fileEntry.strip ())
-        file.close ()
+        file_.close ()
         return filesList
     except Exception:
         print ("Unable to open file: Mono.Design.sources")

--- a/deps/Mono.Design/generate-mono-design.py
+++ b/deps/Mono.Design/generate-mono-design.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import os
 import os.path
 import re

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -4,7 +4,7 @@ make && make run
 
 === On Microsoft .NET with Visual Studio ===
 
-1) Install Python - http://python.org/download/
+1) Install Python 2 or 3 - http://python.org/download/
 2) Run "Prepare Visual Studio Build.bat"
 3) Open mwf-designer.sln with Visual Studio and you are done!
 

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -4,7 +4,7 @@ make && make run
 
 === On Microsoft .NET with Visual Studio ===
 
-1) Install Python 2 or 3 - http://python.org/download/
+1) Install Python 3 - http://python.org/download/
 2) Run "Prepare Visual Studio Build.bat"
 3) Open mwf-designer.sln with Visual Studio and you are done!
 


### PR DESCRIPTION
generate-mono-design.py: renamed variable file to file_
                         git instead of svn url for downloads
Makefile(s): use mcs instead of gmcs
README: Notify user that python 3 is needed
.gitignore: generate-mono-design ignores